### PR TITLE
Update common.test dependency to 1.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
 
         <!-- Library Versions -->
-        <io.paradoxical.common.test>1.0-SNAPSHOT</io.paradoxical.common.test>
+        <io.paradoxical.common.test>1.1-SNAPSHOT</io.paradoxical.common.test>
         <godaddy.logging.version>1.0</godaddy.logging.version>
 
         <dropwizard.version>0.9.1</dropwizard.version>


### PR DESCRIPTION
- Fixes builds, since 1.0-SNAPSHOT was not released
- Points at newest common.test version
