### PR TITLE
Update swagger and okhttp

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.paradoxical</groupId>
         <artifactId>francois</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -26,6 +26,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>okhttp</artifactId>
         </dependency>
 
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.paradoxical</groupId>
         <artifactId>francois</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -141,6 +141,11 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>okhttp</artifactId>
         </dependency>
 
         <dependency>

--- a/core/src/main/java/io/paradoxical/francois/ServiceApplication.java
+++ b/core/src/main/java/io/paradoxical/francois/ServiceApplication.java
@@ -108,7 +108,7 @@ public class ServiceApplication extends Application<ServiceConfiguration> {
                 setContact("admin@francois.io");
                 setPrettyPrint(true);
 
-                setScan(true);
+                setBasePath(environment.getApplicationContext().getContextPath());
 
                 setVersion("1.0");
             }

--- a/core/src/main/java/io/paradoxical/francois/ServiceApplication.java
+++ b/core/src/main/java/io/paradoxical/francois/ServiceApplication.java
@@ -108,7 +108,7 @@ public class ServiceApplication extends Application<ServiceConfiguration> {
                 setContact("admin@francois.io");
                 setPrettyPrint(true);
 
-                setBasePath(environment.getApplicationContext().getContextPath());
+                setScan(true);
 
                 setVersion("1.0");
             }

--- a/core/src/main/java/io/paradoxical/francois/jenkins/JenkinsTemplateManager.java
+++ b/core/src/main/java/io/paradoxical/francois/jenkins/JenkinsTemplateManager.java
@@ -7,11 +7,14 @@ import io.paradoxical.francois.jenkins.templates.TemplateParameter;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public interface JenkinsTemplateManager {
     List<TemplateParameter> getAllParameters(final String templateName) throws IOException;
 
     JobTemplate getJobTemplate(final String jobTemplateName) throws IOException;
+
+    List<JobApplicationModel> listJobs(final Optional<String> searchFilter) throws IOException;
 
     void createJobFromTemplate(String newJobName, String templateName, List<JobParameterValue> parameterValues) throws Exception;
     void updateJobFromTemplate(String jobName, String templateName, List<JobParameterValue> parameterValues) throws Exception;

--- a/core/src/main/java/io/paradoxical/francois/jenkins/TemplateManager.java
+++ b/core/src/main/java/io/paradoxical/francois/jenkins/TemplateManager.java
@@ -179,18 +179,22 @@ public class TemplateManager implements JenkinsTemplateManager {
 
                        if (!promotionCreateResponse.isSuccess()) {
                            if (promotionCreateResponse.code() == 404) {
-                               final Response<ResponseBody> createResponse = jenkinsClient.createPromotion(jobName, promotion.getPromotionName(), promotionConfig)
-                                                                                          .execute();
-
-                               if (!createResponse.isSuccess()) {
-                                   throw new RuntimeException(String.format("Failed to create promotion '%s' on Job '%s'", promotion.getPromotionName(), jobName));
-                               }
+                               createPromotion(jobName, promotion, promotionConfig);
                            }
                            else {
                                throw new RuntimeException(String.format("Failed to update promotion '%s' on Job '%s'", promotion.getPromotionName(), jobName));
                            }
                        }
                    }));
+    }
+
+    private void createPromotion(final String jobName, final PromotionTemplate promotion, final String promotionConfig) throws IOException {
+        final Response<ResponseBody> createResponse = jenkinsClient.createPromotion(jobName, promotion.getPromotionName(), promotionConfig)
+                                                                   .execute();
+
+        if (!createResponse.isSuccess()) {
+            throw new RuntimeException(String.format("Failed to create promotion '%s' on Job '%s'", promotion.getPromotionName(), jobName));
+        }
     }
 
     private String saveJobParameters(final String templateName, final String configXml, final List<JobParameterValue> parameterValues) throws Exception {

--- a/core/src/main/java/io/paradoxical/francois/jenkins/TemplateManager.java
+++ b/core/src/main/java/io/paradoxical/francois/jenkins/TemplateManager.java
@@ -178,7 +178,17 @@ public class TemplateManager implements JenkinsTemplateManager {
                                             .execute();
 
                        if (!promotionCreateResponse.isSuccess()) {
-                           throw new RuntimeException(String.format("Failed to update promotion '%s' on Job '%s'", promotion.getPromotionName(), jobName));
+                           if (promotionCreateResponse.code() == 404) {
+                               final Response<ResponseBody> createResponse = jenkinsClient.createPromotion(jobName, promotion.getPromotionName(), promotionConfig)
+                                                                                          .execute();
+
+                               if (!createResponse.isSuccess()) {
+                                   throw new RuntimeException(String.format("Failed to create promotion '%s' on Job '%s'", promotion.getPromotionName(), jobName));
+                               }
+                           }
+                           else {
+                               throw new RuntimeException(String.format("Failed to update promotion '%s' on Job '%s'", promotion.getPromotionName(), jobName));
+                           }
                        }
                    }));
     }

--- a/core/src/main/java/io/paradoxical/francois/jenkins/TemplateManager.java
+++ b/core/src/main/java/io/paradoxical/francois/jenkins/TemplateManager.java
@@ -9,6 +9,7 @@ import io.paradoxical.francois.exceptions.JobCreateFailureException;
 import io.paradoxical.francois.jenkins.api.ApiConstants;
 import io.paradoxical.francois.jenkins.api.JenkinsApiClient;
 import io.paradoxical.francois.jenkins.api.JobList;
+import io.paradoxical.francois.jenkins.api.JobModel;
 import io.paradoxical.francois.jenkins.templates.JobParameterValue;
 import io.paradoxical.francois.jenkins.templates.JobTemplate;
 import io.paradoxical.francois.jenkins.templates.JobTemplateApplicationConfig;
@@ -22,7 +23,9 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 
@@ -67,16 +70,25 @@ public class TemplateManager implements JenkinsTemplateManager {
     }
 
     @Override
+    public List<JobApplicationModel> listJobs(final Optional<String> searchSubstring) throws IOException {
+        List<JobModel> jobs = jenkinsClient.getTemplatizedJobs().execute().body().getJobs();
+
+        if (searchSubstring.isPresent()) {
+            jobs = jobs.stream().filter(j -> j.getName()
+                                              .toLowerCase()
+                                              .contains(searchSubstring.get().toLowerCase()))
+                       .collect(Collectors.toList());
+        }
+
+        return jobs.stream().map(this::toFullApplicationMode).collect(Collectors.toList());
+    }
+
+    @Override
     public List<JobApplicationModel> getTemplatizedJobs(final String templateName) throws Exception {
         final Response<JobList> response = jenkinsClient.getTemplatizedJobs().execute();
 
         if (response.isSuccess()) {
-
-            final List<JobApplicationModel> jobModels = response.body().getJobs().stream().map(jobModel -> {
-                final JobTemplateApplicationConfig config = loadTemplateConfig(jobModel.getDescription());
-
-                return new JobApplicationModel(jobModel.getName(), config);
-            }).collect(toList());
+            final List<JobApplicationModel> jobModels = response.body().getJobs().stream().map(this::toFullApplicationMode).collect(toList());
 
             return jobModels.stream().filter(jobModel -> isInstanceOfTemplate(templateName, jobModel)).collect(toList());
         }
@@ -245,5 +257,11 @@ public class TemplateManager implements JenkinsTemplateManager {
         catch (IOException e) {
             return null;
         }
+    }
+
+    private JobApplicationModel toFullApplicationMode(JobModel jobModel) {
+        final JobTemplateApplicationConfig config = loadTemplateConfig(jobModel.getDescription());
+
+        return new JobApplicationModel(jobModel.getName(), config);
     }
 }

--- a/core/src/main/java/io/paradoxical/francois/jenkins/TemplateManager.java
+++ b/core/src/main/java/io/paradoxical/francois/jenkins/TemplateManager.java
@@ -226,7 +226,7 @@ public class TemplateManager implements JenkinsTemplateManager {
 
     private JobTemplateApplicationConfig loadTemplateConfig(final String description) {
         try {
-            return new ObjectMapper().readValue(description, JobTemplateApplicationConfig.class);
+            return new ObjectMapper().readValue(description.replace("<pre>", "").replace("</pre>", ""), JobTemplateApplicationConfig.class);
         }
         catch (IOException e) {
             return null;

--- a/core/src/main/java/io/paradoxical/francois/resources/api/v1/FrancoisResource.java
+++ b/core/src/main/java/io/paradoxical/francois/resources/api/v1/FrancoisResource.java
@@ -14,18 +14,21 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 @Path("api/v1/francois")
 @Api(value = "api/v1/francois", description = "Francois api")
@@ -120,6 +123,24 @@ public class FrancoisResource {
         }
         catch (Exception e) {
             logger.error(e, "Error updating job");
+
+            return Response.serverError().build();
+        }
+    }
+
+    @GET
+    @Path("/jobs")
+    @ApiOperation(value = "Search jobs")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
+    public Response searchJobs(
+            @QueryParam("search") String searchString) {
+        try {
+            final List<JobApplicationModel> jobApplicationModels = templateManager.listJobs(Optional.ofNullable(searchString));
+
+            return Response.ok(jobApplicationModels).build();
+        }
+        catch (Exception e) {
+            logger.error(e, "Error searching for jobs");
 
             return Response.serverError().build();
         }

--- a/core/src/main/resources/assets/francois/views/top-nav.html
+++ b/core/src/main/resources/assets/francois/views/top-nav.html
@@ -13,7 +13,7 @@
     </div>
     <div class="top-bar-right">
         <ul class="menu">
-            <li><a href="/swagger">API</a></li>
+            <li><a href="/swagger/ui">API</a></li>
         </ul>
     </div>
 </div>

--- a/core/src/main/resources/templates/freestyleDefault.xml
+++ b/core/src/main/resources/templates/freestyleDefault.xml
@@ -1,6 +1,6 @@
 <project>
     <actions/>
-    <description>{$ Francois.Template.Params $}</description>
+    <description>&lt;pre&gt;&#10;{$ Francois.Template.Params $}&#10;&lt;/pre&gt;&#10;&lt;br/&gt;&lt;hr/&gt;&lt;br/&gt;&#10;</description>
     <keepDependencies>false</keepDependencies>
     <properties/>
     <scm class="hudson.scm.NullSCM"/>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.paradoxical</groupId>
         <artifactId>francois</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     

--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,12 @@
         <java.version>1.8</java.version>
         <retrofit.version>2.0.0-beta2</retrofit.version>
         <retrofit.converter.jackson.version>2.0.0-beta2</retrofit.converter.jackson.version>
+        <ok.http.version>2.7.5</ok.http.version>
         <apache.commons.version>3.3.2</apache.commons.version>
         <javaslang.version>2.0.0-RC1</javaslang.version>
         <commons.io>2.4</commons.io>
 
-        <dropwizard.swagger.version>2.1</dropwizard.swagger.version>
+        <dropwizard.swagger.version>2.2</dropwizard.swagger.version>
         <swagger.version>1.5.6</swagger.version>
 
         <jackson.version>2.6.4</jackson.version>
@@ -153,6 +154,12 @@
                         <artifactId>metrics-core</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.squareup.okhttp</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>2.7.5</version>
             </dependency>
 
             <dependency>
@@ -320,6 +327,12 @@
                 <groupId>com.squareup.retrofit</groupId>
                 <artifactId>retrofit</artifactId>
                 <version>${retrofit.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.squareup.okhttp</groupId>
+                        <artifactId>okhttp</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -330,6 +343,10 @@
                     <exclusion>
                         <groupId>com.fasterxml.jackson.core</groupId>
                         <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.squareup.okhttp</groupId>
+                        <artifactId>okhttp</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
A few things here.  I added support for prettier descriptions with `pre` tags, and had to strip them out when parsing the json

I updated okhttp to be the latest since the version that comes with retrofit doesn't proxy authorization headers if the request returns a 301 moved (so you get 403's)

I updated the swagger link and made sure swagger was working by upgrading the swagger api version
